### PR TITLE
use expm_multiply

### DIFF
--- a/solve.py
+++ b/solve.py
@@ -10,6 +10,7 @@ Description: Simulate quantum annealing with some technique.
 import os
 import scipy as sp
 from scipy import linalg
+import scipy.sparse.linalg
 
 import output
 
@@ -47,8 +48,7 @@ def ExpPert(nQubits, alpha, beta, delta, Psi, T, dt, errchk, eps, outinfo):
         Hexp = 1/(2*T)*((t**2 - t0**2)*(-alpha - beta) - \
                          (2*T*(t - t0) + t0**2 - t**2)*delta)
 
-        A = linalg.expm(-1j*Hexp)
-        Psi = A*Psi
+        Psi = scipy.sparse.linalg.expm_multiply(-1j*Hexp, Psi)
 
         # Get eigendecomposition of true Hamiltonian if necessary
         if (errchk | outinfo['eigdat'] | outinfo['eigplot'] \


### PR DESCRIPTION
I added a pull request to the scipy master branch to improve the support for complex numbers in expm_multiply, and I've also changed this in solve.py in AdiaQC.

Here's the scipy pull request, so that it doesn't complain about imaginary numbers.
https://github.com/scipy/scipy/pull/2495

Using expm_multiply(A, B) instead of expm(A)*B seems to improve the hopfield.py speed from

```
real    0m16.593s
user    0m33.914s
sys     0m59.272s
```

to

```
real    0m13.787s
user    0m23.701s
sys     0m53.507s
```

although I don't really know how to run the AdiaQC tests.

For the quantsigtest the improvement is more dramatic, from

```
real    0m47.133s
```

to

```
real    0m9.735s
```
